### PR TITLE
fix: Re-enable Vercel Analytics and Speed Insights

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -361,10 +361,14 @@ const combinedSchema = schema ? [organizationSchema, websiteSchema, schema] : [o
 		<Footer />
 		
 		
-		<!-- Vercel Analytics - Temporarily removed due to TypeScript issues -->
-		<!-- <Analytics /> -->
+		<!-- Vercel Analytics -->
+		<script>
+			import('@vercel/analytics').then(({ inject }) => inject());
+		</script>
 		
-		<!-- Vercel Speed Insights - Temporarily removed due to TypeScript issues -->
-		<!-- <SpeedInsights /> -->
+		<!-- Vercel Speed Insights -->
+		<script>
+			import('@vercel/speed-insights').then(({ injectSpeedInsights }) => injectSpeedInsights());
+		</script>
 	</body>
 </html>


### PR DESCRIPTION
- Fixed commented out Vercel Analytics integration in Layout.astro
- Used dynamic imports to avoid TypeScript compilation issues
- Both Analytics and Speed Insights now loading properly
- Resolves 3-day gap in analytics data collection