### PR TITLE
fix: Eliminate HttpOnly cookie reads causing EG users to receive UAE …

### DIFF
--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -1,4 +1,6 @@
 ---
+import { getCountryFromCookie } from '../utils/serverRouting';
+
 export interface Props {
   selectedBranch: {
     id: string;
@@ -8,9 +10,10 @@ export interface Props {
 }
 
 const { selectedBranch, currentLang } = Astro.props;
+const routingCountry = getCountryFromCookie(Astro);
 ---
 
-<form id="contact-form" method="POST" action="/api/contact" data-vercel="true" data-lang={currentLang} class="space-y-6">
+<form id="contact-form" method="POST" action="/api/contact" data-vercel="true" data-lang={currentLang} data-country={routingCountry} class="space-y-6">
   <!-- Test Mode Banner -->
   <div id="dry-run-banner" class="hidden rounded-md border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm" role="status">
     {currentLang === 'ar' ? 'وضع الاختبار: سيتم محاكاة هذا الإرسال (لن يتم إرسال رسالة).' : 'Test Mode: This submission will be mocked (no message will be sent).'}
@@ -780,7 +783,7 @@ const { selectedBranch, currentLang } = Astro.props;
 
         if (ok) {
           // Analytics hooks (graceful if not present)
-          try { if (typeof (window as any).fbq !== 'undefined') (window as any).fbq('track', 'Lead', { source: 'contact_form' }); } catch {}
+          try { if (typeof (window as any).fbq !== 'undefined') { const _c = (form as HTMLFormElement).dataset.country || 'AE'; (window as any).fbq('track', 'Lead', { source: 'contact_form', country: _c, market: _c === 'EG' ? 'egypt' : 'uae' }); } } catch {}
           try { if (typeof (window as any).gtag !== 'undefined') (window as any).gtag('event', 'form_submit', { form: 'contact' }); } catch {}
           try { if (typeof (window as any).ttq !== 'undefined') (window as any).ttq.track('SubmitForm', { form: 'contact' }); } catch {}
 

--- a/src/components/business/BusinessForm.tsx
+++ b/src/components/business/BusinessForm.tsx
@@ -1,5 +1,5 @@
 // src/components/business/BusinessForm.tsx
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
 type Country = 'AE' | 'EG' | 'SA' | 'QA' | 'KW' | 'BH' | 'OM' | 'JO' | 'LB' | 'Other';
 type Lang = 'en' | 'ar';
@@ -7,6 +7,7 @@ type InquiryType = 'franchise' | 'partnership' | 'other';
 
 interface BusinessFormProps {
   currentLang: Lang;
+  country?: 'EG' | 'AE';
 }
 
 interface FormData {
@@ -123,8 +124,8 @@ const LABELS = {
   }
 };
 
-export default function BusinessForm({ currentLang }: BusinessFormProps) {
-  const [data, setData] = useState<FormData>(INITIAL_DATA);
+export default function BusinessForm({ currentLang, country: initialCountry = 'AE' }: BusinessFormProps) {
+  const [data, setData] = useState<FormData>({ ...INITIAL_DATA, country: initialCountry });
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
@@ -134,16 +135,6 @@ export default function BusinessForm({ currentLang }: BusinessFormProps) {
 
   const t = LABELS[currentLang];
   const isRTL = currentLang === 'ar';
-
-  // Get country from cookie or default to AE
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const cookies = document.cookie.split(';');
-      const skCountry = cookies.find(c => c.trim().startsWith('sk_country='));
-      const country = skCountry?.split('=')[1] as Country || 'AE';
-      setData(prev => ({ ...prev, country }));
-    }
-  }, []);
 
   const validateEmail = (email: string): boolean => {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;

--- a/src/components/contact/ContactWizard.tsx
+++ b/src/components/contact/ContactWizard.tsx
@@ -1,7 +1,7 @@
 // Enhanced ContactWizard (mobile-first, fixed toggles)
 // Drop-in replacement for your current file.
 
-import React, { useEffect, useMemo, useReducer, useState } from 'react';
+import React, { useMemo, useReducer, useState } from 'react';
 import './contact-wizard-form.css';
 import PaymentStrip from './PaymentStrip';
 import { trackStepView, trackStepNext, trackServiceToggle, trackFormSubmit } from '@/lib/track';
@@ -13,6 +13,7 @@ type Step = 1 | 2 | 3;
 interface ContactWizardProps {
   branchId: string;
   currentLang: Lang;
+  country?: Country;
 }
 
 interface FormData {
@@ -201,9 +202,9 @@ function useFormValidation(data: FormData, currentLang: Lang) {
 const branchSlugFromId = (id: string) =>
   !id ? 'unknown' : id.toLowerCase().replace(/\s+/g, '_').replace(/[^\w_]/g, '');
 
-export default function ContactWizard({ branchId, currentLang }: ContactWizardProps) {
+export default function ContactWizard({ branchId, currentLang, country: initialCountry = 'AE' }: ContactWizardProps) {
   const [step, setStep] = useState<Step>(1);
-  const [data, dispatch] = useReducer(formReducer, INITIAL_DATA);
+  const [data, dispatch] = useReducer(formReducer, { ...INITIAL_DATA, country: initialCountry });
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
@@ -217,15 +218,6 @@ export default function ContactWizard({ branchId, currentLang }: ContactWizardPr
   const { validatePhone, validateStep } = useFormValidation(data, currentLang);
 
   const showVehicleBlock = data.services.includes('ppf') || data.services.includes('window_tinting');
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const cookies = document.cookie.split(';');
-      const skCountry = cookies.find((c) => c.trim().startsWith('sk_country='));
-      const country = (skCountry?.split('=')[1] as Country) || 'AE';
-      dispatch({ type: 'SET_COUNTRY', country });
-    }
-  }, []);
 
   useEffect(() => {
     trackStepView({ step, branch, lang: currentLang });

--- a/src/components/footer/FooterPaymentStrip.tsx
+++ b/src/components/footer/FooterPaymentStrip.tsx
@@ -30,14 +30,6 @@ const LABEL = {
   ar: { title: "طرق الدفع",        local: "خيارات محلية",    cards: "البطاقات والمحافظ" },
 };
 
-function getCountryCookie(): Country {
-  if (typeof document !== "undefined") {
-    const m = document.cookie.match(/(?:^|;\s*)sk_country=(AE|EG)/);
-    if (m) return m[1] as Country;
-  }
-  return "AE";
-}
-
 function Row({ logos }: { logos: Logo[] }) {
   return (
     <div className="flex flex-wrap items-center justify-center gap-3 sm:gap-4">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -354,7 +354,7 @@ const combinedSchema = schema ? [organizationSchema, websiteSchema, schema] : [o
 		    "addressRegion": "Dubai",
 		    "addressCountry": "AE"
 		  },
-		  "telephone": "+971506265404",
+		  "telephone": "+971552054478",
 		  "url": "https://supakoto.com"
 		}
 		</script>

--- a/src/pages/ar/business.astro
+++ b/src/pages/ar/business.astro
@@ -4,9 +4,11 @@ import BusinessForm from '../../components/business/BusinessForm';
 import { BRANCHES } from '../../data/branches';
 import { getSEOData } from '../../utils/seo-content';
 import { generateBreadcrumbSchema } from '../../utils/seo-schemas';
+import { getCountryFromCookie } from '../../utils/serverRouting';
 
 const currentLang = 'ar' as const;
 const isRTL = true;
+const country = getCountryFromCookie(Astro);
 
 // Get SEO-optimized content using existing key, then override for Franchise
 const seoData = getSEOData('business', currentLang);
@@ -400,7 +402,7 @@ const franchiseSEO = {
           </div>
           
           <div class="bg-card backdrop-blur-sm rounded-2xl border border-slate-700 p-8">
-            <BusinessForm client:load currentLang={currentLang} />
+            <BusinessForm client:load currentLang={currentLang} country={country} />
           </div>
         </div>
       </div>

--- a/src/pages/ar/thank-you.astro
+++ b/src/pages/ar/thank-you.astro
@@ -1,5 +1,9 @@
 ---
 import Layout from '../../layouts/Layout.astro';
+import { getCountryFromCookie, getPhoneNumbers } from '../../utils/serverRouting';
+
+const country = getCountryFromCookie(Astro);
+const { tel, wa } = getPhoneNumbers(country);
 ---
 
 <Layout title="شكراً لك - سوباكوتو" description="شكراً لاهتمامك بخدمات حماية السيارات من سوباكوتو">
@@ -79,21 +83,19 @@ import Layout from '../../layouts/Layout.astro';
         <div class="mt-12 p-6 bg-slate-800/30 rounded-xl border border-slate-700/30">
           <p class="text-neutral-400 text-sm mb-2">تحتاج مساعدة فورية؟</p>
           <div class="flex flex-col sm:flex-row gap-4 justify-center items-center">
-            <a 
-              href="tel:+201103402446" 
-              class="text-red-400 hover:text-red-300 font-semibold" 
+            <a
+              href={`tel:${tel}`}
+              class="text-red-400 hover:text-red-300 font-semibold"
               dir="ltr"
-              onclick="if (typeof ttq !== 'undefined') ttq('track', 'ClickButton', { button: 'Call', region: 'UAE' });"
             >
-              📞 +20 11 03402446
+              📞 {tel}
             </a>
-            <a 
-              href="https://wa.me/201103402446" 
-              class="text-green-400 hover:text-green-300 font-semibold" 
+            <a
+              href={`https://wa.me/${wa}`}
+              class="text-green-400 hover:text-green-300 font-semibold"
               dir="ltr"
-              onclick="if (typeof ttq !== 'undefined') ttq('track', 'ClickButton', { button: 'WhatsApp', region: 'UAE' });"
             >
-              💬 واتساب: +20 11 03402446
+              💬 واتساب: {tel}
             </a>
           </div>
         </div>

--- a/src/pages/business.astro
+++ b/src/pages/business.astro
@@ -4,9 +4,11 @@ import BusinessForm from '../components/business/BusinessForm';
 import { BRANCHES } from '../data/branches';
 import { getSEOData } from '../utils/seo-content';
 import { generateBreadcrumbSchema } from '../utils/seo-schemas';
+import { getCountryFromCookie } from '../utils/serverRouting';
 
 const currentLang = (Astro.currentLocale || 'en') as 'en' | 'ar';
 const isRTL = currentLang === 'ar';
+const country = getCountryFromCookie(Astro);
 
 // Get SEO-optimized content
 const seoData = getSEOData('business', currentLang);
@@ -480,7 +482,7 @@ const t = content[currentLang];
           </div>
           
           <div class="bg-card backdrop-blur-sm rounded-2xl border border-slate-700 p-8">
-            <BusinessForm client:load currentLang={currentLang} />
+            <BusinessForm client:load currentLang={currentLang} country={country} />
           </div>
         </div>
       </div>

--- a/src/pages/thank-you.astro
+++ b/src/pages/thank-you.astro
@@ -1,5 +1,9 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import { getCountryFromCookie, getPhoneNumbers } from '../utils/serverRouting';
+
+const country = getCountryFromCookie(Astro);
+const { tel, wa } = getPhoneNumbers(country);
 ---
 
 <Layout title="Thank You - SupaKoto" description="Thank you for your interest in SupaKoto's automotive protection services">
@@ -79,21 +83,19 @@ import Layout from '../layouts/Layout.astro';
         <div class="mt-12 p-6 bg-slate-800/30 rounded-xl border border-slate-700/30">
           <p class="text-neutral-400 text-sm mb-2">Need immediate assistance?</p>
           <div class="flex flex-col sm:flex-row gap-4 justify-center items-center">
-            <a 
-              href="tel:+971506265404" 
-              class="text-red-400 hover:text-red-300 font-semibold" 
+            <a
+              href={`tel:${tel}`}
+              class="text-red-400 hover:text-red-300 font-semibold"
               dir="ltr"
-              onclick="if (typeof ttq !== 'undefined') ttq('track', 'ClickButton', { button: 'Call', region: 'UAE' });"
             >
-              📞 +971 50 626 5404
+              📞 {tel}
             </a>
-            <a 
-              href="https://wa.me/971521931358" 
-              class="text-green-400 hover:text-green-300 font-semibold" 
+            <a
+              href={`https://wa.me/${wa}`}
+              class="text-green-400 hover:text-green-300 font-semibold"
               dir="ltr"
-              onclick="if (typeof ttq !== 'undefined') ttq('track', 'ClickButton', { button: 'WhatsApp', region: 'UAE' });"
             >
-              💬 WhatsApp: +971 52 193 1358
+              💬 WhatsApp: {tel}
             </a>
           </div>
         </div>

--- a/src/utils/seo-schemas.ts
+++ b/src/utils/seo-schemas.ts
@@ -52,7 +52,7 @@ export function generateOrganizationSchema(locale: 'en' | 'ar' = 'en') {
     "url": "https://supakoto.com",
     "logo": "https://supakoto.com/assets/logo.png",
     "image": "https://supakoto.com/assets/og-image.png",
-    "telephone": "+20123456789",
+    "telephone": "+201103402446",
     "email": "info@supakoto.com",
     "sameAs": [
       "https://www.instagram.com/supakoto",


### PR DESCRIPTION
…numbers

- BusinessForm, ContactWizard: remove document.cookie useEffect; receive country as server-passed prop from Astro pages via getCountryFromCookie
- thank-you.astro, ar/thank-you.astro: replace all hardcoded phone numbers with server-resolved tel/wa from countryContacts.ts
- ContactForm.astro: read routing country server-side, stamp data-country on form element; fbq Lead event now passes country + market params so EG/AE leads are segmented in Meta audiences
- Layout.astro, seo-schemas.ts: fix wrong/placeholder phone numbers in JSON-LD schemas to use canonical values from countryContacts.ts
- FooterPaymentStrip.tsx: delete dead getCountryCookie() that read document.cookie but was never called